### PR TITLE
Zac/feature/carousel view

### DIFF
--- a/src/Components/Carousel/Carousel.tsx
+++ b/src/Components/Carousel/Carousel.tsx
@@ -15,17 +15,16 @@ const Carousel = ({ albums, artist }: Props) => {
 
   const displayAlbums = albums.map((album, index) => {
     return (
-      <div
+      <Link
         className="album-tile" 
         key={index} 
+        to={`/album/${formatURLString(artist)}/${formatURLString(album.name)}`}
       >
         <img
         src={album.picURL}
         />
-        <Link className={'class'} to={`/album/${formatURLString(artist)}/${formatURLString(album.name)}`}>Click</Link>
-
         <h2>{album.name}</h2>
-      </div>
+      </Link>
     ) 
   })
 

--- a/src/Components/Carousel/Carousel.tsx
+++ b/src/Components/Carousel/Carousel.tsx
@@ -1,11 +1,34 @@
 import React from 'react'
 
-const Carousel = () => {
-  return (
-    <div>
-      
-    </div>
-  )
+type Props = {
+  albums: Array<
+  {name: string, 
+    picURL: string
+  }
+  >
 }
+
+const Carousel = ({ albums }: Props) => {
+
+  const displayAlbums = albums.map((album, index) => {
+    return (
+      <div 
+        className="albumTile" 
+        key={index} 
+        style={{ 
+          backgroundImage: `url(${album.picURL})` 
+        }}
+      >{album.name}</div>
+    ) 
+      })
+
+    return (
+      <div className="carousel-container">
+        {displayAlbums}
+      </div>
+    )
+  }
+
+
 
 export default Carousel

--- a/src/Components/Carousel/Carousel.tsx
+++ b/src/Components/Carousel/Carousel.tsx
@@ -21,6 +21,7 @@ const Carousel = ({ albums, artist }: Props) => {
         to={`/album/${formatURLString(artist)}/${formatURLString(album.name)}`}
       >
         <img
+        className="album-image"
         src={album.picURL}
         />
         <h2>{album.name}</h2>

--- a/src/Components/Carousel/Carousel.tsx
+++ b/src/Components/Carousel/Carousel.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
+import './_Carousel.scss';
 
 type Props = {
-  albums: Array<
-  {name: string, 
+  albums: Array<{
+    name: string, 
     picURL: string
-  }
-  >
+  }>
 }
 
 const Carousel = ({ albums }: Props) => {
@@ -13,14 +13,16 @@ const Carousel = ({ albums }: Props) => {
   const displayAlbums = albums.map((album, index) => {
     return (
       <div 
-        className="albumTile" 
+        className="album-tile" 
         key={index} 
-        style={{ 
-          backgroundImage: `url(${album.picURL})` 
-        }}
-      >{album.name}</div>
+      >
+        <img
+        src={album.picURL}
+        />
+        <h2>{album.name}</h2>
+      </div>
     ) 
-      })
+  })
 
     return (
       <div className="carousel-container">

--- a/src/Components/Carousel/Carousel.tsx
+++ b/src/Components/Carousel/Carousel.tsx
@@ -1,24 +1,29 @@
 import React from 'react'
-import './_Carousel.scss';
+import './_Carousel.scss'
+import formatURLString from '../../Helper/CleanUp'
+import { Link } from 'react-router-dom'
 
 type Props = {
   albums: Array<{
     name: string, 
     picURL: string
   }>
+  artist: string
 }
 
-const Carousel = ({ albums }: Props) => {
+const Carousel = ({ albums, artist }: Props) => {
 
   const displayAlbums = albums.map((album, index) => {
     return (
-      <div 
+      <div
         className="album-tile" 
         key={index} 
       >
         <img
         src={album.picURL}
         />
+        <Link className={'class'} to={`/album/${formatURLString(artist)}/${formatURLString(album.name)}`}>Click</Link>
+
         <h2>{album.name}</h2>
       </div>
     ) 

--- a/src/Components/Carousel/_Carousel.scss
+++ b/src/Components/Carousel/_Carousel.scss
@@ -1,3 +1,10 @@
 @use '../../Utilities/mixins';
 @use '../../Utilities/variables';
 
+.album-tile {
+    margin: 1vw;
+    width: 30vw;
+    height: 40vw;
+    white-space: normal;
+}
+

--- a/src/Components/Carousel/_Carousel.scss
+++ b/src/Components/Carousel/_Carousel.scss
@@ -12,3 +12,8 @@
     text-decoration: inherit;
 }
 
+.album-image {
+    width:30vw;
+    height: 30vw;
+}
+

--- a/src/Components/Carousel/_Carousel.scss
+++ b/src/Components/Carousel/_Carousel.scss
@@ -1,2 +1,3 @@
 @use '../../Utilities/mixins';
 @use '../../Utilities/variables';
+

--- a/src/Components/Carousel/_Carousel.scss
+++ b/src/Components/Carousel/_Carousel.scss
@@ -5,6 +5,10 @@
     margin: 1vw;
     width: 30vw;
     height: 40vw;
+    border-radius: 1vh;
+    box-shadow: 2px 2px 2px black;
     white-space: normal;
+    color: inherit;
+    text-decoration: inherit;
 }
 

--- a/src/Components/SearchForm/SearchForm.tsx
+++ b/src/Components/SearchForm/SearchForm.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import './_SearchForm.scss'
+import './_SearchForm.scss';
 import ArtistResults from '../ArtistResults/ArtistResults';
+import Carousel from '../Carousel/Carousel';
 
 
 const SearchForm = () => {
@@ -78,7 +79,7 @@ const SearchForm = () => {
         </Link>
       </form>
       {(searchName && !selectedArtist) && <ArtistResults searchName={searchName} results={searchResults}/>}
-      {selectedArtist && <p>Carousel goes here</p>}
+        {selectedArtist && <Carousel albums={ albumsByArtist } />}
     </div>
   )
 }

--- a/src/Components/SearchForm/SearchForm.tsx
+++ b/src/Components/SearchForm/SearchForm.tsx
@@ -79,7 +79,8 @@ const SearchForm = () => {
         </Link>
       </form>
       {(searchName && !selectedArtist) && <ArtistResults searchName={searchName} results={searchResults}/>}
-        {selectedArtist && <Carousel albums={ albumsByArtist } />}
+        {selectedArtist && 
+        <Carousel albums={ albumsByArtist } artist={ selectedArtist } />}
     </div>
   )
 }

--- a/src/Components/SearchForm/_SearchForm.scss
+++ b/src/Components/SearchForm/_SearchForm.scss
@@ -37,12 +37,13 @@
 
 .carousel-container {
   display: flex;
-  justify-content: center;
   align-items: center;
   flex-direction: row;
   margin: 5%;
   width: 80vw;
   height: 60vh;
   border-style: solid;
-  overflow-y:auto
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: nowrap;
 }

--- a/src/Components/SearchForm/_SearchForm.scss
+++ b/src/Components/SearchForm/_SearchForm.scss
@@ -34,3 +34,15 @@
   border-radius: 60px;
   font-size: 1em;
 }
+
+.carousel-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: row;
+  margin: 5%;
+  width: 80vw;
+  height: 60vh;
+  border-style: solid;
+  overflow-y:auto
+}

--- a/src/Helper/CleanUp.tsx
+++ b/src/Helper/CleanUp.tsx
@@ -1,1 +1,9 @@
 import React from "react";
+
+const formatURLString = (item: string) => {
+    const lowerCaseItem = item.toLowerCase()
+    const spaceToPlus = lowerCaseItem.replaceAll(' ', '+')
+    return spaceToPlus
+  }
+  
+  export default formatURLString


### PR DESCRIPTION
#### What does this PR do?

- Adds carousel view to the search form view when an artist is selected
- Adds a clean up function to format url from artist and album names
- Carousel can be clicked to view album details page

#### What (if any) features are you implementing?

- carousel view and url formatting

#### Were there any issues that arose?

- too many

#### Any other comments, questions, or concerns?

- initial PR to unblock any potential functionality reliant on the carousel
- the styling will drastically change (hopefully), a lot of research is needed
- really hoping its within the mvp!
 
#### Screenshots (if applicable)

<img width="1104" alt="image" src="https://user-images.githubusercontent.com/22826695/211065576-4475d02d-44c4-4f6f-baee-a2c82fc4f336.png">

