### PR TITLE
Brett/testing/searchtests

### DIFF
--- a/cypress/e2e/search.cy.ts
+++ b/cypress/e2e/search.cy.ts
@@ -1,17 +1,18 @@
 /// <reference types="cypress" />
 // @ts-check
 
+
 describe('Search Page Functionality', () => {
 
   beforeEach(() => {
-    
     cy.intercept(`http://ws.audioscrobbler.com/2.0/?method=artist.search&artist=Smash%20Mouth&api_key=fcf48a134034bb684aa87d0e0309a0fd%20%20%20%20&format=json`, {
       method: 'GET',
       fixture: '../fixtures/searchResults.json'
     });
-
-    //additional intercept for next fetches
-
+    cy.intercept(`http://ws.audioscrobbler.com/2.0/?method=artist.gettopalbums&artist=Smash%20Mouth&api_key=fcf48a134034bb684aa87d0e0309a0fd&format=json`, {
+      method: 'GET',
+      fixture: '../fixtures/searchResultsAlbums.json'
+    })
     cy.visit('http://localhost:3000/search');
   })
 
@@ -52,6 +53,23 @@ describe('Search Page Functionality', () => {
     cy.get('.artist-results-section')
       .get('#0')
       .should('have.attr', 'href', '/search/Smash Mouth/Smash Mouth')
+  });
+
+  it('Should retrieve albums data when clicking on a search result', () => {
+    cy.get('.search-input')
+    .type('Smash Mouth')
+
+    cy.get('.search-button')
+      .click()
+
+    cy.get('.artist-results-section')
+      .get('#0')
+      .click();
+
+    /*
+      Incomplete, need check carousel for visual confirmation 
+      but I did verify that state does update to the stubbed fixture data
+    */
   });
 
 })

--- a/cypress/e2e/search.cy.ts
+++ b/cypress/e2e/search.cy.ts
@@ -10,7 +10,7 @@ describe('Search Page Functionality', () => {
       fixture: '../fixtures/searchResults.json'
     });
 
-    //additional intercept for next fetch
+    //additional intercept for next fetches
 
     cy.visit('http://localhost:3000/search');
   })
@@ -40,6 +40,18 @@ describe('Search Page Functionality', () => {
     cy.contains('Results for "Smash Mouth"')
     cy.contains('Smash Mouth')
     cy.contains('Smash Mouth (Holiday)')
+  });
+
+  it('The search results should be links', () => {
+    cy.get('.search-input')
+    .type('Smash Mouth')
+
+    cy.get('.search-button')
+      .click()
+
+    cy.get('.artist-results-section')
+      .get('#0')
+      .should('have.attr', 'href', '/search/Smash Mouth/Smash Mouth')
   });
 
 })

--- a/cypress/e2e/search.cy.ts
+++ b/cypress/e2e/search.cy.ts
@@ -1,0 +1,45 @@
+/// <reference types="cypress" />
+// @ts-check
+
+describe('Search Page Functionality', () => {
+
+  beforeEach(() => {
+    
+    cy.intercept(`http://ws.audioscrobbler.com/2.0/?method=artist.search&artist=Smash%20Mouth&api_key=fcf48a134034bb684aa87d0e0309a0fd%20%20%20%20&format=json`, {
+      method: 'GET',
+      fixture: '../fixtures/searchResults.json'
+    });
+
+    //additional intercept for next fetch
+
+    cy.visit('http://localhost:3000/search');
+  })
+
+  it('Should have a heading', () => {
+    cy.contains('Explore')
+  });
+
+  it('Should have a form for the user to type the name of their very favorite artist to search', () => {
+    cy.get('.search-input')
+      .type('Smash Mouth')
+      .should('have.value', "Smash Mouth")
+  });
+
+  it('Should have a search button that searches for the great artist user typed', () => {
+    cy.get('.search-button')
+      .click()
+  });
+
+  it('Should display search results', () => {
+    cy.get('.search-input')
+      .type('Smash Mouth')
+ 
+    cy.get('.search-button')
+      .click()
+
+    cy.contains('Results for "Smash Mouth"')
+    cy.contains('Smash Mouth')
+    cy.contains('Smash Mouth (Holiday)')
+  });
+
+})

--- a/cypress/fixtures/searchResults.json
+++ b/cypress/fixtures/searchResults.json
@@ -1,0 +1,10 @@
+{
+  "results": {
+    "artistmatches": {
+      "artist": [
+        {"name": "Smash Mouth"},
+        {"name": "Smash Mouth (Holiday)"}
+      ]
+    }
+  }
+}

--- a/cypress/fixtures/searchResultsAlbums.json
+++ b/cypress/fixtures/searchResultsAlbums.json
@@ -1,0 +1,14 @@
+{
+  "topalbums": {
+    "album": [
+      {
+        "name": "Astro Lounge",
+        "image": [{}, {}, {}, {"#text": "https://lastfm.freetls.fastly.net/i/u/300x300/3db4107a5144e5bcb69b40206808c72f.png"}]
+      }, 
+      {
+        "name": "Shrek",
+        "image": [{}, {}, {}, {"#text": "https://lastfm.freetls.fastly.net/i/u/300x300/8480262a95ed44939bcb7119d6ffd952.png"}]
+      }
+    ]
+  }
+}

--- a/src/Components/ArtistResults/ArtistResults.tsx
+++ b/src/Components/ArtistResults/ArtistResults.tsx
@@ -11,7 +11,7 @@ const ArtistResults = ({results, searchName}: Props) => {
 
   const artistsList = results.map((result, index) => {
     return (
-      <SearchResult name={result} searchName={searchName} key={index}/>
+      <SearchResult name={result} searchName={searchName} key={index} id={index}/>
     )
   })
 

--- a/src/Components/SearchResult/SearchResult.tsx
+++ b/src/Components/SearchResult/SearchResult.tsx
@@ -5,14 +5,15 @@ import './_SearchResult.scss'
 type Props = {
   name: string;
   searchName: string;
+  id: number;
 }
 
-const SearchResult = ({name, searchName}: Props) => {
+const SearchResult = ({name, searchName, id}: Props) => {
 
 
 
   return (
-    <Link to={`/search/${searchName}/${name}`}>
+    <Link to={`/search/${searchName}/${name}`} id={`${id}`}>
       <p className='search-result'>{name}</p>
     </Link>
   )


### PR DESCRIPTION
#### What does this PR do?
This adds a test spec for testing the search functionality. It adds 2 json fixtures for when the 2 respective fetch get requests are fired off and supply small sample data. It tests up until the albums are displayed.

#### What (if any) features are you implementing?
n/a

#### What (if anything) did you refactor?
Added an ID property to the individual search results items

#### Were there any issues that arose?
n/a

#### Any other comments, questions, or concerns?
Please let me know if you see anything missing that should be tested or better ways to do so, also it's incomplete in the sense that it doesn't test the carousel component (the results of the 2nd fetch call) but it does fully test the artist search.

#### Screenshots (if applicable)
