### PR TITLE
PATCH: Missing Album Data/Carousel Link Issue

### DIFF
--- a/cypress/e2e/AlbumDetails_spec.cy.ts
+++ b/cypress/e2e/AlbumDetails_spec.cy.ts
@@ -18,6 +18,68 @@ describe("Album Details Page", () => {
     cy.get('[data-cy="directory-artist"]').should("have.text", "The Beatles")
     cy.get('[data-cy="directory-album"]').should("have.text", " / Rubber Soul")
     cy.get('[data-cy="album-name"]').should("have.text", "Rubber Soul")
+  })
 
+  it("should display the correctly formatted release date", () => {
+    cy.get('[data-cy="album-date"]').should("have.text", "released on: Jan 1, 2009")
+  })
+
+  it("should link to the correct Last.fm URL", () => {
+    cy.get('[data-cy="album-link"]').invoke("attr", "href").should("eq", "https://www.last.fm/music/The+Beatles/Rubber+Soul")
+  })
+
+  it("should display the correctly-formatted album article", () => {
+    cy.get('[data-cy="album-article"]').should("have.text", "Rubber Soul is the sixth studio album by the English rock band The Beatles. Released in December 1965, and produced by George Martin, Rubber Soul was recorded in just over four weeks to make the Christmas market. Showcasing a sound influenced by the folk rock of The Byrds and Bob Dylan, the album was seen as a major artistic achievement for the band, attaining widespread critical and commercial success, with reviewers taking note of The Beatles' developing musical vision. In 2003, the album was ranked number 5 on Rolling Stone magazine's list of the 500 greatest albums of all time. ... (cont.)")
+  })
+
+  it("should display the correct tracklist", () => {
+    cy.get('[data-cy="album-tracklist"]').find("li").first()
+      .should("have.text", "Drive My Car")
+      .next()
+      .should("have.text", "Norwegian Wood (This Bird Has Flown)")
+      .next()
+      .should("have.text", "You Won't See Me")
+      .next()
+      .should("have.text", "Nowhere Man")
+      .next()
+      .should("have.text", "Think for Yourself")
+      .next()
+      .should("have.text", "The Word")
+      .next()
+      .should("have.text", "Michelle")
+      .next()
+      .should("have.text", "What Goes On")
+      .next()
+      .should("have.text", "Girl")
+      .next()
+      .should("have.text", "I'm Looking Through You")
+      .next()
+      .should("have.text", "In My Life")
+      .next()
+      .should("have.text", "Wait")
+      .next()
+      .should("have.text", "If I Needed Someone")
+      .next()
+      .should("have.text", "Run for Your Life")
+  })
+
+  it("should display the correct album cover", () => {
+    cy.get('[data-cy="album-cover"]').invoke("attr", "src").should("eq", "https://lastfm.freetls.fastly.net/i/u/300x300/72ed10a859fb4c1fb29a546078ec737d.png")
+  })
+
+  it("should allow a user to add the displayed album to their collection", () => {
+    cy.get('[data-cy="add-button"]').click()
+    cy.get('[data-cy="saved-message"]').should("be.visible")
+  })
+
+  it("should only show the \"add to collection\" button if the album has not been previously saved", () => {
+    cy.get('[data-cy="add-button"]').click()
+    cy.get('[data-cy="add-button"]').should("not.exist")
+  })
+
+  it("should only show the \"album is saved in collection\" message if the album has been previously saved", () => {
+    cy.get('[data-cy="saved-message"]').should("not.exist")
+    cy.get('[data-cy="add-button"]').click()
+    cy.get('[data-cy="saved-message"]').should("be.visible")
   })
 })

--- a/src/Components/AlbumDetails/AlbumDetails.tsx
+++ b/src/Components/AlbumDetails/AlbumDetails.tsx
@@ -1,5 +1,5 @@
 import {FC, useEffect, useState} from "react"
-import {useParams} from "react-router-dom"
+import {useParams, Link} from "react-router-dom"
 
 import "./_AlbumDetails.scss"
 import {AlbumInterface} from "../../Helper/fetchPage"
@@ -43,16 +43,18 @@ const AlbumDetails: FC<Props> = ({addToCollection, userCollection, album}) => {
   }
 
   const getReleaseDate = () => {
-    const returnedDate: string = formatReleaseDate(album.releaseDate!)
+    const returnedDate: string = formatReleaseDate(album.releaseDate)
     formattedDate = returnedDate
     return returnedDate
   }
 
   let formattedDate: string
 
-  const tracks = album.tracks.map(track => {
-    return <li key={track.trackNum}>{track.name}</li>
-  })
+  const tracks = !!album.tracks
+    ? album.tracks.map(track => {
+        return <li key={track.trackNum}>{track.name}</li>
+      })
+    : null
 
   const previouslySavedMessage = (
     <div className="saved-message" data-cy="saved-message">
@@ -60,15 +62,15 @@ const AlbumDetails: FC<Props> = ({addToCollection, userCollection, album}) => {
     </div>
   )
 
-  const articleIndex = album.article.indexOf("<")
-  const formattedArticle = album.article.substring(0, articleIndex)
+  const formattedArticle = !!album.article
+    ? album.article.substring(0, album.article.indexOf("<"))
+    : null
 
   return (
     <>
       <span className="directory">
         <span className="directory__artist" data-cy="directory-artist">
-          {album.artist}
-          {/* <Link /> to SearchForm with current artist as query can go here later */}
+          <Link to={`/search/${artistName}`}>{album.artist}</Link>
         </span>
         <span className="directory__album" data-cy="directory-album">
           {" "}
@@ -92,20 +94,22 @@ const AlbumDetails: FC<Props> = ({addToCollection, userCollection, album}) => {
             </button>
           )}
           <p className="album-details__date" data-cy="album-date">
-            released on: {album.releaseDate && getReleaseDate()}
+            {!!album.releaseDate && `released on: ${getReleaseDate()}`}
           </p>
           <article className="album-details__article" data-cy="album-article">
-            {formattedArticle}{"... (cont.)"}
+            {!!formattedArticle && `${formattedArticle}... (cont.)`}
           </article>
           <p className="album-details__last-link">
-            {"view more on "}
+            {"view on "}
             <a href={album.lastURL} data-cy="album-link">
               Last.fm
             </a>
           </p>
-          <ol className="album-details__tracklist" data-cy="album-tracklist">
-            {tracks}
-          </ol>
+          {!!tracks &&
+            <ol className="album-details__tracklist" data-cy="album-tracklist">
+              {tracks}
+            </ol>
+          }
         </div>
         <div className="cover">
           <div className="cover__mat">

--- a/src/Components/AlbumDetails/AlbumDetails.tsx
+++ b/src/Components/AlbumDetails/AlbumDetails.tsx
@@ -55,7 +55,7 @@ const AlbumDetails: FC<Props> = ({addToCollection, userCollection, album}) => {
   })
 
   const previouslySavedMessage = (
-    <div className="saved-message">
+    <div className="saved-message" data-cy="saved-message">
       <p>this album is saved in your collection</p>
     </div>
   )
@@ -95,8 +95,7 @@ const AlbumDetails: FC<Props> = ({addToCollection, userCollection, album}) => {
             released on: {album.releaseDate && getReleaseDate()}
           </p>
           <article className="album-details__article" data-cy="album-article">
-            {formattedArticle}
-            {/* {formattedArticle.length < album.article.length } */}
+            {formattedArticle}{"... (cont.)"}
           </article>
           <p className="album-details__last-link">
             {"view more on "}

--- a/src/Helper/CleanUp.tsx
+++ b/src/Helper/CleanUp.tsx
@@ -1,9 +1,7 @@
-import React from "react";
-
 const formatURLString = (item: string) => {
-    const lowerCaseItem = item.toLowerCase()
-    const spaceToPlus = lowerCaseItem.replaceAll(' ', '+')
-    return spaceToPlus
+    return item.toLowerCase()
+      .replaceAll(' ', '+')
+      .replace(/\//g, "+")
   }
   
   export default formatURLString

--- a/src/Helper/fetchPage.tsx
+++ b/src/Helper/fetchPage.tsx
@@ -5,15 +5,15 @@ export const fetchPage = async (url: string): Promise<AlbumInterface> => {
     name: album.name,
     artist: album.artist,
     image: album.image[4]["#text"],
-    tracks: album.tracks.track.map((track: FetchedTrack) => ({
+    tracks: !!album.tracks ? album.tracks.track.map((track: FetchedTrack) => ({
       name: track.name,
       duration: track.duration,
       trackNum: track["@attr"]["rank"],
       artist: album.artist,
       album: album.name
-    })),
-    releaseDate: album.wiki.published,
-    article: album.wiki.summary,
+    })) : null,
+    releaseDate: !!album.wiki?.published ? album.wiki.published : null,
+    article: !!album.wiki?.summary ? album.wiki.summary : null,
     lastURL: album.url
   }
 }


### PR DESCRIPTION
#### What does this PR do?

Patches two bugs:
1. `AlbumDetails` crashing when server returns certain missing data
2. album tiles in `Carousel` were linking to the wrong URL (via helper function `formatURLString()`)

#### Solutions

1. `fetchPage` and `AlbumDetails` now account for missing data and conditionally render certain elements based on that data's availability
2. `formatURLString()` now replaces forward slashes in album titles with plus signs, enabling `fetchPage` to fetch the correct data

#### What (if anything) did you refactor?

`formatURLString()` was also refactored for easier readability.

#### Any other comments, questions, or concerns?

Since `fetchPage` will now assign missing data to `null`, and that data is used to add an album to the user's collection, `null` values for data may need to be accounted for in `UserCollection` (although User Collection functionality appears to be working okay for now).