### PR TITLE
Brett/refactor/searchalbumsupdate

### DIFF
--- a/cypress/fixtures/searchResultsAlbums.json
+++ b/cypress/fixtures/searchResultsAlbums.json
@@ -2,10 +2,12 @@
   "topalbums": {
     "album": [
       {
+        "artist":{"name": "Smash Mouth"},
         "name": "Astro Lounge",
         "image": [{}, {}, {}, {"#text": "https://lastfm.freetls.fastly.net/i/u/300x300/3db4107a5144e5bcb69b40206808c72f.png"}]
       }, 
       {
+        "artist":{"name": "Smash Mouth"},
         "name": "Shrek",
         "image": [{}, {}, {}, {"#text": "https://lastfm.freetls.fastly.net/i/u/300x300/8480262a95ed44939bcb7119d6ffd952.png"}]
       }

--- a/src/Components/Carousel/Carousel.tsx
+++ b/src/Components/Carousel/Carousel.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom'
 
 type Props = {
   albums: Array<{
+    artist: string,
     name: string, 
     picURL: string
   }>

--- a/src/Components/SearchForm/SearchForm.tsx
+++ b/src/Components/SearchForm/SearchForm.tsx
@@ -5,6 +5,12 @@ import ArtistResults from '../ArtistResults/ArtistResults';
 import Carousel from '../Carousel/Carousel';
 
 
+interface FetchAlbumsDatum {
+  artist: {name: string},
+  name: string, 
+  image: [{size: string, '#text': string}, {size: string, '#text': string}, {size: string, '#text': string}, {size: string, '#text': string}]
+}
+
 const SearchForm = () => {
 
   const [searchField, setSearchField] = useState('');
@@ -18,9 +24,15 @@ const SearchForm = () => {
     &format=json`)
       .then(response => response.json())
       .then(data => {
+        console.log('search artists data: ', data);
+        
+
         setSearchResults(
           data.results.artistmatches.artist.map((datum: {name: string}) => datum.name)
         );
+
+        //clean up & to replace with 'and'? fetch doesn't seem to recognize '&' if it's in the name, only shows first artist
+
       });
     clearSearchField();
   }
@@ -29,14 +41,18 @@ const SearchForm = () => {
     fetch(`http://ws.audioscrobbler.com/2.0/?method=artist.gettopalbums&artist=${selectedArtist}&api_key=fcf48a134034bb684aa87d0e0309a0fd&format=json`)
       .then(response => response.json())
       .then(data => {
-        setAlbumsByArtist(
-          data.topalbums.album.map((datum: 
-            {name: string, 
-            image: [{size: string, '#text': string}, {size: string, '#text': string}, {size: string, '#text': string}, {size: string, '#text': string}]}
-            ) => {
-            return {name: datum.name, picURL: datum.image[3]['#text']}
-          })
-        )
+        console.log('getAlubms data: ', data);
+        
+        const fetchedAlbums = data.topalbums.album.map((datum: FetchAlbumsDatum) => {
+          return {
+            artist: datum.artist.name,
+            name: datum.name, 
+            picURL: datum.image[3]['#text']
+          }
+        })
+        //clean up functions: remove null/blank names; if no img url, supply a basic stock record; filter out any that are too "niche"? Only top 20?
+        //error handling - sometimes just because Last.fm gives you an artist name, doesn't mean they have any album data and will throw an error (see Smash Mouth)
+        setAlbumsByArtist(fetchedAlbums)
       })
   }
 

--- a/src/Components/SearchForm/SearchForm.tsx
+++ b/src/Components/SearchForm/SearchForm.tsx
@@ -11,6 +11,10 @@ interface FetchAlbumsDatum {
   image: [{size: string, '#text': string}, {size: string, '#text': string}, {size: string, '#text': string}, {size: string, '#text': string}]
 }
 
+interface  FetchArtistsDatum {
+  name: string
+}
+
 const SearchForm = () => {
 
   const [searchField, setSearchField] = useState('');
@@ -24,15 +28,9 @@ const SearchForm = () => {
     &format=json`)
       .then(response => response.json())
       .then(data => {
-        console.log('search artists data: ', data);
-        
-
-        setSearchResults(
-          data.results.artistmatches.artist.map((datum: {name: string}) => datum.name)
-        );
-
-        //clean up & to replace with 'and'? fetch doesn't seem to recognize '&' if it's in the name, only shows first artist
-
+        const fetchedArtists = data.results.artistmatches.artist.map((datum: FetchArtistsDatum) => datum.name)
+        //clean up functions: fix '&' to replace with 'and', fetch doesn't seem to recognize '&' if it's in the name, only shows first artist
+        setSearchResults(fetchedArtists);
       });
     clearSearchField();
   }
@@ -41,8 +39,6 @@ const SearchForm = () => {
     fetch(`http://ws.audioscrobbler.com/2.0/?method=artist.gettopalbums&artist=${selectedArtist}&api_key=fcf48a134034bb684aa87d0e0309a0fd&format=json`)
       .then(response => response.json())
       .then(data => {
-        console.log('getAlubms data: ', data);
-        
         const fetchedAlbums = data.topalbums.album.map((datum: FetchAlbumsDatum) => {
           return {
             artist: datum.artist.name,
@@ -51,7 +47,7 @@ const SearchForm = () => {
           }
         })
         //clean up functions: remove null/blank names; if no img url, supply a basic stock record; filter out any that are too "niche"? Only top 20?
-        //error handling - sometimes just because Last.fm gives you an artist name, doesn't mean they have any album data and will throw an error (see Smash Mouth)
+        //error handling - sometimes just because Last.fm gives you an artist name, doesn't mean they have any album data and will throw an error (see Smash Mouth and owl city)
         setAlbumsByArtist(fetchedAlbums)
       })
   }

--- a/src/Components/SearchForm/SearchForm.tsx
+++ b/src/Components/SearchForm/SearchForm.tsx
@@ -4,17 +4,8 @@ import './_SearchForm.scss';
 import ArtistResults from '../ArtistResults/ArtistResults';
 import Carousel from '../Carousel/Carousel';
 import fetchData from '../../Helper/APIcalls';
+import { FetchAlbumsDatum, FetchArtistsDatum } from '../../interfaces';
 
-
-interface FetchAlbumsDatum {
-  artist: {name: string},
-  name: string, 
-  image: [{size: string, '#text': string}, {size: string, '#text': string}, {size: string, '#text': string}, {size: string, '#text': string}]
-}
-
-interface  FetchArtistsDatum {
-  name: string
-}
 
 const SearchForm = () => {
 

--- a/src/Components/SearchForm/SearchForm.tsx
+++ b/src/Components/SearchForm/SearchForm.tsx
@@ -97,7 +97,7 @@ const SearchForm = () => {
         </Link>
       </form>
       {(searchName && !selectedArtist) && <ArtistResults searchName={searchName} results={searchResults}/>}
-        {selectedArtist && 
+      {selectedArtist && 
         <Carousel albums={ albumsByArtist } artist={ selectedArtist } />}
     </div>
   )

--- a/src/Helper/APIcalls.tsx
+++ b/src/Helper/APIcalls.tsx
@@ -1,1 +1,15 @@
 import React from "react"
+
+const fetchData = (url: string) => {
+  return fetch(url).then(response => {
+    if (response.ok) {
+      return response.json()
+    } else {
+      console.log('bad response: ', response);
+      
+      throw new Error('**record scratch** ....something went wrong')
+    }
+  })
+}
+
+export default fetchData

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,0 +1,12 @@
+
+
+
+export interface FetchAlbumsDatum {
+  artist: {name: string},
+  name: string, 
+  image: [{size: string, '#text': string}, {size: string, '#text': string}, {size: string, '#text': string}, {size: string, '#text': string}]
+}
+
+export interface  FetchArtistsDatum {
+  name: string
+}


### PR DESCRIPTION
#### What does this PR do?
1. It adds an artist name property to the state array of albums (previously just had the album name and image) and subsequently updates Carousel type and the json fixture that stubs for the test spec.
2. It creates interfaces for the data received from both the artist and albums search.
3. It creates a file specifically for interfaces and moves above interfaces to this file.
4. It creates a basic fetch API call set up for error handling in the APIcalls file and exports that function to SearchForm.
5. It adds basic error handling to SearchForm (more still needed). Discovered that sometimes, just because Last.fm provides you an artist name does not mean that it has albums and will send an error; however the response is still '.ok' so needed to create a conditional in the .then that handles data to throw an error.

#### What (if any) features are you implementing?
n/a

#### What (if anything) did you refactor?
SearchForm, with updates to Carousel, APIcalls, searchResultsAlbums.json, and created a file for interfaces.

#### Were there any issues that arose?
Testing edge cases for data, discovering lots of holes in API data we're getting that will affect AlbumDetails

#### Any other comments, questions, or concerns?

#### Screenshots (if applicable)
